### PR TITLE
Add IndicatorType/Related_Campaigns

### DIFF
--- a/campaign.xsd
+++ b/campaign.xsd
@@ -72,6 +72,10 @@
 					<xs:element name="Related_Indicators" type="campaign:RelatedIndicatorsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Indicators field identifies or characterizes one or more cyber threat Indicators related to this cyber threat Campaign.</xs:documentation>
+							<xs:documentation>NOTE: As of STIX Version 1.1, this field is deprecated and is scheduled to be removed in STIX Version 2.0. Relationships between indicators and campaigns should be represented using the Related_Campaigns field on IndicatorType unless legacy code or content requires the use of this field.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Attribution" type="campaign:AttributionType" minOccurs="0" maxOccurs="unbounded">

--- a/indicator.xsd
+++ b/indicator.xsd
@@ -117,6 +117,11 @@
 							<xs:documentation>The Related_Indicators field is optional and enables content producers to express a relationship between the enclosing indicator (i.e., the subject of the relationship) and a disparate indicator (i.e., the object side of the relationship).</xs:documentation>
 						</xs:annotation>
 					</xs:element>
+					<xs:element name="Related_Campaigns" type="indicator:RelatedCampaignReferencesType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>The Related_Campaigns field captures references to related campaigns. Note that unlike most other relationship types, Related_Campaigns does not allow campaigns to be embedded, only referenced via name or ID.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
 					<xs:element name="Producer" type="stixCommon:InformationSourceType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Producer field details the source of this entry.</xs:documentation>
@@ -306,6 +311,15 @@
 			<xs:element name="Test_Mechanism" type="indicator:TestMechanismType" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The TestMechanism field specifies a non-standard Test Mechanism effective at identifying the cyber Observables specified in this cyber threat Indicator. This field is defined as of type TestMechanismType which is an abstract type enabling the extension and inclusion of various formats of Test Mechanism specifications.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RelatedCampaignReferencesType">
+		<xs:sequence>
+			<xs:element name="Related_Campaign" type="stixCommon:CampaignReferenceType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The Related_Campaign field captures a single relationship to a related campaign.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 		</xs:sequence>

--- a/stix_common.xsd
+++ b/stix_common.xsd
@@ -289,6 +289,49 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="RelatedCampaignReferenceType">
+		<xs:annotation>
+			<xs:documentation>Identifies or characterizes a relationship by reference to a campaign.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="stixCommon:GenericRelationshipType">
+				<xs:sequence>
+					<xs:element name="Campaign" type="stixCommon:CampaignReferenceType">
+						<xs:annotation>
+							<xs:documentation>A reference to the related campaign.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:complexType name="CampaignReferenceType">
+		<xs:annotation>
+			<xs:documentation>Characterizes a reference to a campaign.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Names" type="stixCommon:NamesType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Specifies one or more campaign names for a cyber threat campaign defined elsewhere.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+		<xs:attribute name="idref" type="xs:QName">
+			<xs:annotation>
+				<xs:documentation>Specifies a globally unique identifier for a cyber threat campaign defined elsewhere.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+	<xs:complexType name="NamesType">
+		<xs:sequence>
+			<xs:element name="Name" type="stixCommon:ControlledVocabularyStringType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The Name field specifies a Name used to identify a Campaign. This field can be used to capture various aliases used to identify this Campaign.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. No default vocabulary type has been defined for STIX 1.0. Users may either define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a free string field.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
 	<xs:complexType name="RelatedCourseOfActionType">
 		<xs:annotation>
 			<xs:documentation>Identifies or characterizes a relationship to a course of action.</xs:documentation>


### PR DESCRIPTION
Also adds a deprecation notice to the corresponding field in CampaignType. One question here is what to do about NamesType: currently it's duplicated across the campaign schema and the stixCommon schema to avoid potential compatibility issues (due to different namespaces).

Fixes #55.
