### PR TITLE
Indicator => Campaign reference appears to be broken, #152

### DIFF
--- a/indicator.xsd
+++ b/indicator.xsd
@@ -342,7 +342,7 @@
 		<xs:complexContent>
 			<xs:extension base="stixCommon:GenericRelationshipListType">
 				<xs:sequence>
-					<xs:element name="Related_Campaign" type="stixCommon:CampaignReferenceType" maxOccurs="unbounded">
+					<xs:element name="Related_Campaign" type="stixCommon:RelatedCampaignReferenceType" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Related_Campaign field captures a single relationship to a related campaign.</xs:documentation>
 						</xs:annotation>


### PR DESCRIPTION
This was applied to the wrong branch (master), and I accidentally merged it. This one is applied to the correct branch.
