### PR TITLE
Support multiple Descriptions on all data elements

### DIFF
--- a/campaign.xsd
+++ b/campaign.xsd
@@ -31,12 +31,12 @@
 							<xs:documentation>The Title field provides a simple title for this Campaign.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description of this Campaign.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this Campaign.</xs:documentation>
 						</xs:annotation>

--- a/course_of_action.xsd
+++ b/course_of_action.xsd
@@ -44,12 +44,12 @@
 							<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. The default vocabulary type is CourseOfActionTypeVocab-1.0 in the http://stix.mitre.org/default_vocabularies-1 namespace. This type is defined in the stix_default_vocabularies.xsd file or at the URL http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description of this CourseOfAction.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this CourseOfAction.</xs:documentation>
 						</xs:annotation>
@@ -155,12 +155,12 @@
 			<xs:documentation>The ObjectiveType characterizes the objective of this CourseOfAction.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of the objective of this CourseOfAction.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of the objective of this CourseOfAction.</xs:documentation>
 				</xs:annotation>

--- a/exploit_target.xsd
+++ b/exploit_target.xsd
@@ -31,12 +31,12 @@
 							<xs:documentation>The Title field provides a simple title for this ExploitTarget.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description of this ExploitTarget.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this ExploitTarget.</xs:documentation>
 						</xs:annotation>
@@ -113,12 +113,12 @@
 					<xs:documentation>The Title field provides a simple title for this vulnerability.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field provides an unstructured, text description of this vulnerability.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field provides a short, unstructured, text description of this vulnerability.</xs:documentation>
 				</xs:annotation>
@@ -195,12 +195,12 @@
 	</xs:complexType>
 	<xs:complexType name="ConfigurationType">
 		<xs:sequence>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of this Configuration.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this Configuration.</xs:documentation>
 				</xs:annotation>
@@ -219,7 +219,7 @@
 	</xs:complexType>
 	<xs:complexType name="WeaknessType">
 		<xs:sequence>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of this Weakness.</xs:documentation>
 				</xs:annotation>

--- a/extensions/test_mechanism/generic_test_mechanism.xsd
+++ b/extensions/test_mechanism/generic_test_mechanism.xsd
@@ -19,7 +19,7 @@
         <xs:complexContent>
             <xs:extension base="indicator:TestMechanismType">
                 <xs:sequence>
-                    <xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+                    <xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
                         <xs:annotation>
                             <xs:documentation>A structured Description of this Generic Test Mechanism.</xs:documentation>
                         </xs:annotation>

--- a/incident.xsd
+++ b/incident.xsd
@@ -42,12 +42,12 @@
 							<xs:documentation>The Time field specifies relevant time values associated with this Incident.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description of this Incident.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this Incident.</xs:documentation>
 						</xs:annotation>
@@ -217,7 +217,7 @@
 					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description_Of_Effect" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description_Of_Effect" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description_Of_Effect field is optional and provides a brief prose description of how the security property was affected.</xs:documentation>
 				</xs:annotation>
@@ -252,12 +252,12 @@
 					<xs:documentation>The Type field is optional and specifies the type of the asset impacted by the incident (a security attribute was negatively affected).</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of the asset.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Business_Function_Or_Role" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Business_Function_Or_Role" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Business_Function_Or_Role field is optional and provides a brief description of the asset's role, mission, and importance within the organization.</xs:documentation>
 				</xs:annotation>

--- a/indicator.xsd
+++ b/indicator.xsd
@@ -43,12 +43,12 @@
 							<xs:documentation>Specifies an alternative identifier (or alias) for the cyber threat Indicator.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description for this Indicator.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides an unstructured, text description for this Indicator.</xs:documentation>
 						</xs:annotation>
@@ -278,7 +278,7 @@
 					<xs:documentation>This field provides a confidence assertion in the accuracy of this sighting.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and enables an unstructured, text description of this Sighting.</xs:documentation>
 				</xs:annotation>

--- a/stix_common.xsd
+++ b/stix_common.xsd
@@ -17,7 +17,7 @@
 			<xs:documentation>The InformationSourceType details the source of a given data entry.</xs:documentation>
 		</xs:annotation>
 		<xs:sequence>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field provides a description of this information source.</xs:documentation>
 				</xs:annotation>
@@ -70,7 +70,7 @@
 					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field provides a description of the confidence value and how it was derived.</xs:documentation>
 				</xs:annotation>
@@ -108,7 +108,7 @@
 					<xs:documentation>In order to avoid ambiguity, it is strongly suggest that all timestamps include a specification of the timezone if it is known.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field provides a description of the activity.</xs:documentation>
 				</xs:annotation>
@@ -723,7 +723,7 @@
 					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>Specifies a prose description of the statement.</xs:documentation>
 				</xs:annotation>
@@ -758,6 +758,22 @@
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:extension base="xs:string">
+				<xs:attribute name="id" type="xs:QName" use="optional">
+				    <xs:annotation>
+				      <xs:documentation>Specifies a globally unique identifier for
+				        this Description.</xs:documentation>
+				    </xs:annotation>
+				  </xs:attribute>
+				  <xs:attribute name="ordinality"  type="xs:positiveInteger" use="optional">
+				    <xs:annotation>
+				      <xs:documentation>Specifies the intended order position of this construct
+				        instance (e.g. Description) within a set of potentially multiple peer
+				        construct instances. If only a single construct instance is
+				        present its ordinality can be assumed to be 1. If multiple
+				        construct instances are present, the ordinality field should
+				        be specified with unique values for each instance.</xs:documentation>
+				    </xs:annotation>
+				  </xs:attribute>
 				<xs:attribute name="structuring_format" type="xs:string" use="optional">
 					<xs:annotation>
 						<xs:documentation>Used to indicate a particular structuring format (e.g., HTML5) used within an instance of StructuredTextType. Note that if the markup tags used by this format would be interpreted as XML information (such as the bracket-based tags of HTML) the text area should be enclosed in a CDATA section to prevent the markup from interferring with XML validation of the STIX document. If this attribute is absent, the implication is that no markup is being used.</xs:documentation>
@@ -912,7 +928,7 @@
 							<xs:documentation>The Title field provides a simple title for a single tool leveraged by this TTP item.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of a single tool leveraged by this TTP item.</xs:documentation>
 						</xs:annotation>

--- a/stix_core.xsd
+++ b/stix_core.xsd
@@ -124,12 +124,12 @@
 					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field provides a description of this package of STIX content.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field provides a short description of this package of STIX content.</xs:documentation>
 				</xs:annotation>

--- a/test_manifest.cfg
+++ b/test_manifest.cfg
@@ -13,6 +13,7 @@ issues/issue_218/oldvocab.xml,pos
 issues/issue_135/cvrf_extension.xml,pos
 issues/issue_244/invalid_value.xml,neg
 issues/issue_244/versioning_vocab.xml,pos
+issues/issue_186/multidesc.xml,pos
 veris/0001AA7F-C601-424A-B2B8-BE6C9F5164E7.xml,pos
 veris/0012CC25-9167-40D8-8FE3-3D0DFD8FB6BB.xml,pos
 veris/00163384-B4D7-46D5-9E6F-543DFB00F598.xml,pos

--- a/threat_actor.xsd
+++ b/threat_actor.xsd
@@ -32,12 +32,12 @@
 							<xs:documentation>The Title field provides a simple title for this ThreatActor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description of this ThreatActor.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this ThreatActor.</xs:documentation>
 						</xs:annotation>

--- a/ttp.xsd
+++ b/ttp.xsd
@@ -35,12 +35,12 @@
 							<xs:documentation>The Title field provides a simple title for this TTP.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Description field is optional and provides an unstructured, text description of this TTP.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
-					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+					<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of this TTP.</xs:documentation>
 						</xs:annotation>
@@ -134,12 +134,12 @@
 					<xs:documentation>The Title field provides a simple title for an individual Attack Pattern.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of an individual Attack Pattern.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of an individual Attack Pattern.</xs:documentation>
 				</xs:annotation>
@@ -190,12 +190,12 @@
 					<xs:documentation>The Title field is optional and provides an unstructured, text description of an individual Malware Instance.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field provides an text description of an individual Malware Instance.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field provides a short text description of an individual Malware Instance.</xs:documentation>
 				</xs:annotation>
@@ -223,12 +223,12 @@
 					<xs:documentation>The Title field provides a simple title for an individual Exploit instance.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of an individual Exploit Instance.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of an individual Exploit Instance.</xs:documentation>
 				</xs:annotation>
@@ -272,12 +272,12 @@
 					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Description field is optional and provides an unstructured, text description of specific classes or instances of infrastructure utilized for cyber attack.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
-			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0">
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
 					<xs:documentation>The Short_Description field is optional and provides a short, unstructured, text description of specific classes or instances of infrastructure utilized for cyber attack.</xs:documentation>
 				</xs:annotation>


### PR DESCRIPTION
I'm going to go ahead and rebase this PR and move "add uniqueness constraint for @ordinality" into [a new branch](https://github.com/STIXProject/schemas/tree/multi-desc-enforce) for archival. Also merged [the tests](https://github.com/STIXProject/schemas-test/pull/6)

The net effect is that:
- multiple descriptions will be supported (i.e. everything that uses `StructuredTextType` )
- our Travis tests will comprehensively cover use cases and not worry about 'uniqueness' constraints
- end user clients *will* need to check whether ordinality uniqueness is violated, and handle those errors as desired.

cc:@jwunder
