### PR TITLE
Created the Report object as a separate component based on STIX_Package

### DIFF
--- a/report.xsd
+++ b/report.xsd
@@ -22,7 +22,7 @@
 			<xs:documentation>ReportType defines a contextual wrapper for a grouping of STIX constructs.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
-			<xs:extension base="stixCommon:CourseOfActionBaseType">
+			<xs:extension base="stixCommon:ReportBaseType">
 				<xs:sequence>
 					<xs:element name="Header" type="report:HeaderType" minOccurs="0">
 						<xs:annotation>

--- a/report.xsd
+++ b/report.xsd
@@ -1,0 +1,207 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:cybox="http://cybox.mitre.org/cybox-2" xmlns:report="http://stix.mitre.org/Report-1" xmlns:marking="http://data-marking.mitre.org/Marking-1" xmlns:stixCommon="http://stix.mitre.org/common-1" xmlns:cyboxCommon="http://cybox.mitre.org/common-2" xmlns:campaign="http://stix.mitre.org/Campaign-1" xmlns:coa="http://stix.mitre.org/CourseOfAction-1" xmlns:et="http://stix.mitre.org/ExploitTarget-1" xmlns:incident="http://stix.mitre.org/Incident-1" xmlns:indicator="http://stix.mitre.org/Indicator-2" xmlns:ta="http://stix.mitre.org/ThreatActor-1" xmlns:ttp="http://stix.mitre.org/TTP-1" targetNamespace="http://stix.mitre.org/Report-1" elementFormDefault="qualified" attributeFormDefault="unqualified" version="1.2" xml:lang="en">
+	<xs:annotation>
+		<xs:documentation>This schema was originally developed by The MITRE Corporation. The STIX XML Schema implementation is maintained by The MITRE Corporation and developed by the open STIX Community. For more information, including how to get involved in the effort and how to submit change requests, please visit the STIX website at http://stix.mitre.org. </xs:documentation>
+		<xs:appinfo>
+			<version>1.2</version>
+			<date>04/15/2015 9:00:00 AM</date>
+			<short_description>Structured Threat Information eXpression (STIX) - Schematic implementation for a structured cyber threat expression language architecture.</short_description>
+			<terms_of_use>Copyright (c) 2012-2015, The MITRE Corporation. All rights reserved. The contents of this file are subject to the terms of the STIX License located at http://stix.mitre.org/about/termsofuse.html. See the STIX License for the specific language governing permissions and limitations for use of this schema. When distributing copies of the STIX Schema, this license header must be included. </terms_of_use>
+		</xs:appinfo>
+	</xs:annotation>
+	<xs:import namespace="http://stix.mitre.org/common-1" schemaLocation="stix_common.xsd"/>
+	<xs:import namespace="http://cybox.mitre.org/cybox-2" schemaLocation="cybox/cybox_core.xsd"/>
+	<xs:import namespace="http://data-marking.mitre.org/Marking-1" schemaLocation="data_marking.xsd"/>
+	<xs:element name="Report" type="report:ReportType">
+		<xs:annotation>
+			<xs:documentation>The Report construct gives context to a grouping of STIX constructs.</xs:documentation>
+		</xs:annotation>
+	</xs:element>
+	<xs:complexType name="ReportType">
+		<xs:annotation>
+			<xs:documentation>ReportType defines a contextual wrapper for a grouping of STIX constructs.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="stixCommon:CourseOfActionBaseType">
+				<xs:sequence>
+					<xs:element name="Header" type="report:HeaderType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>The Header field provides the contextual information for this grouping of STIX content.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Observables" type="cybox:ObservablesType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more cyber observables.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Indicators" type="report:IndicatorsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more cyber threat Indicators.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="TTPs" type="report:TTPsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more cyber threat adversary Tactics, Techniques or Procedures.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Exploit_Targets" type="stixCommon:ExploitTargetsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more potential targets for exploitation.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Incidents" type="report:IncidentsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more cyber threat Incidents.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Courses_Of_Action" type="report:CoursesOfActionType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes Courses of Action to be taken in regards to one of more cyber threats.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Campaigns" type="report:CampaignsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more cyber threat Campaigns.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Threat_Actors" type="report:ThreatActorsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more cyber Threat Actors.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+					<xs:element name="Related_Reports" type="report:RelatedReportsType" minOccurs="0">
+						<xs:annotation>
+							<xs:documentation>Characterizes one or more relationships to other Reports.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+				<xs:attribute name="version" type="report:ReportVersionEnum">
+					<xs:annotation>
+						<xs:documentation>Specifies the relevant Report schema version for this content.</xs:documentation>
+					</xs:annotation>
+				</xs:attribute>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+	<xs:simpleType name="ReportVersionEnum">
+		<xs:annotation>
+			<xs:documentation>An enumeration of all versions of Report types valid in the current release of STIX.</xs:documentation>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="1.0"/>
+		</xs:restriction>
+	</xs:simpleType>
+	<xs:complexType name="HeaderType">
+		<xs:annotation>
+			<xs:documentation>The HeaderType provides a structure for characterizing the contextual information in a Report of STIX content.</xs:documentation>
+		</xs:annotation>
+		<xs:sequence>
+			<xs:element name="Title" type="xs:string" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The Title field provides a simple title for this Report.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Intent" type="stixCommon:ControlledVocabularyStringType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The Intent field characterizes the intended purpose(s) or use(s) for this package of STIX content.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. The default vocabulary type is PackageIntentVocab-1.0 in the http://stix.mitre.org/default_vocabularies-1 namespace. This type is defined in the stix_default_vocabularies.xsd file or at the URL http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd.</xs:documentation>
+					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The Description field provides a description of this package of STIX content.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The Short_Description field provides a short description of this package of STIX content.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Handling" type="marking:MarkingType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>Specifies the relevant handling guidance for this Report. The valid marking scope is the nearest ReportType ancestor of this Handling element and all its descendants.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+			<xs:element name="Information_Source" type="stixCommon:InformationSourceType" minOccurs="0">
+				<xs:annotation>
+					<xs:documentation>The Information_Source field details the source of this Report, including time information as well as information about the producer, contributors, tools, and references.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<!---->
+	<xs:complexType name="IndicatorsType">
+		<xs:sequence>
+			<xs:element name="Indicator" type="stixCommon:IndicatorBaseType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Characterizes a single cyber threat Indicator.</xs:documentation>
+					<xs:documentation>	This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is IndicatorType in the http://stix.mitre.org/Indicator-2 namespace. This type is defined in the indicator.xsd file or at the URL http://stix.mitre.org/XMLSchema/indicator/2.1/indicator.xsd.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="TTPsType">
+		<xs:sequence>
+			<xs:element name="TTP" type="stixCommon:TTPBaseType" minOccurs="0" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Characterizes a single cyber threat adversary Tactic, Technique or Procedure.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is TTPType in the http://stix.mitre.org/TTP-1 namespace. This type is defined in the ttp.xsd file or at the URL http://stix.mitre.org/XMLSchema/ttp/1.1.1/ttp.xsd.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="IncidentsType">
+		<xs:sequence>
+			<xs:element name="Incident" type="stixCommon:IncidentBaseType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Identifies or characterizes a single cyber threat Incident.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is IncidentType in the http://stix.mitre.org/Incident-1 namespace. This type is defined in the incident.xsd file or at the URL http://stix.mitre.org/XMLSchema/incident/1.1.1/incident.xsd.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CoursesOfActionType">
+		<xs:sequence>
+			<xs:element name="Course_Of_Action" type="stixCommon:CourseOfActionBaseType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>The Course_Of_Action field characterizes a Course of Action to be taken in regards to one of more cyber threats.</xs:documentation>
+					<xs:documentation>	This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is CourseOfActionType in the http://stix.mitre.org/CourseOfAction-1 namespace. This type is defined in the course_of_action.xsd file or at the URL http://stix.mitre.org/XMLSchema/course_of_action/1.1.1/course_of_action.xsd.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="CampaignsType">
+		<xs:sequence>
+			<xs:element name="Campaign" type="stixCommon:CampaignBaseType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Characterizes a single cyber threat Campaign.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is CampaignType in the http://stix.mitre.org/Campaign-1 namespace. This type is defined in the campaign.xsd file or at the URL http://stix.mitre.org/XMLSchema/campaign/1.1.1/campaign.xsd.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="ThreatActorsType">
+		<xs:sequence>
+			<xs:element name="Threat_Actor" type="stixCommon:ThreatActorBaseType" maxOccurs="unbounded">
+				<xs:annotation>
+					<xs:documentation>Characterizes a single cyber Threat Actor.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is ThreatActorType in the http://stix.mitre.org/ThreatActor-1 namespace. This type is defined in the threat_actor.xsd file or at the URL http://stix.mitre.org/XMLSchema/threat_actor/1.1.1/threat_actor.xsd.</xs:documentation>
+				</xs:annotation>
+			</xs:element>
+		</xs:sequence>
+	</xs:complexType>
+	<xs:complexType name="RelatedReportsType">
+		<xs:complexContent>
+			<xs:extension base="stixCommon:GenericRelationshipListType">
+				<xs:sequence>
+					<xs:element name="Related_Report" type="stixCommon:RelatedReportType" maxOccurs="unbounded">
+						<xs:annotation>
+							<xs:documentation>The Related_Report field is optional and enables content producers to express a relationship between the enclosing report (i.e., the subject of the relationship) and a disparate report (i.e., the object side of the relationship).</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
+</xs:schema>

--- a/report.xsd
+++ b/report.xsd
@@ -14,12 +14,12 @@
 	<xs:import namespace="http://data-marking.mitre.org/Marking-1" schemaLocation="data_marking.xsd"/>
 	<xs:element name="Report" type="report:ReportType">
 		<xs:annotation>
-			<xs:documentation>The Report construct gives context to a grouping of STIX constructs.</xs:documentation>
+			<xs:documentation>The Report construct gives context to a grouping of STIX content.</xs:documentation>
 		</xs:annotation>
 	</xs:element>
 	<xs:complexType name="ReportType">
 		<xs:annotation>
-			<xs:documentation>ReportType defines a contextual wrapper for a grouping of STIX constructs.</xs:documentation>
+			<xs:documentation>ReportType defines a contextual wrapper for a grouping of STIX content.</xs:documentation>
 		</xs:annotation>
 		<xs:complexContent>
 			<xs:extension base="stixCommon:ReportBaseType">
@@ -103,19 +103,19 @@
 			</xs:element>
 			<xs:element name="Intent" type="stixCommon:ControlledVocabularyStringType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>The Intent field characterizes the intended purpose(s) or use(s) for this package of STIX content.</xs:documentation>
-					<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. The default vocabulary type is PackageIntentVocab-1.0 in the http://stix.mitre.org/default_vocabularies-1 namespace. This type is defined in the stix_default_vocabularies.xsd file or at the URL http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd.</xs:documentation>
+					<xs:documentation>The Intent field characterizes the intended purpose(s) or use(s) for this Report.</xs:documentation>
+					<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. The default vocabulary type is ReportIntentVocab-1.0 in the http://stix.mitre.org/default_vocabularies-1 namespace. This type is defined in the stix_default_vocabularies.xsd file or at the URL http://stix.mitre.org/XMLSchema/default_vocabularies/1.1.1/stix_default_vocabularies.xsd.</xs:documentation>
 					<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>The Description field provides a description of this package of STIX content.</xs:documentation>
+					<xs:documentation>The Description field provides a description of this Report.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Short_Description" type="stixCommon:StructuredTextType" minOccurs="0" maxOccurs="unbounded">
 				<xs:annotation>
-					<xs:documentation>The Short_Description field provides a short description of this package of STIX content.</xs:documentation>
+					<xs:documentation>The Short_Description field provides a short description of this Report.</xs:documentation>
 				</xs:annotation>
 			</xs:element>
 			<xs:element name="Handling" type="marking:MarkingType" minOccurs="0">

--- a/stix_common.xsd
+++ b/stix_common.xsd
@@ -480,6 +480,23 @@
 			</xs:extension>
 		</xs:complexContent>
 	</xs:complexType>
+	<xs:complexType name="RelatedReportType">
+		<xs:annotation>
+			<xs:documentation>Identifies or characterizes a relationship to a report.</xs:documentation>
+		</xs:annotation>
+		<xs:complexContent>
+			<xs:extension base="stixCommon:GenericRelationshipType">
+				<xs:sequence>
+					<xs:element name="Report" type="stixCommon:ReportBaseType" minOccurs="1">
+						<xs:annotation>
+							<xs:documentation>A reference or representation of the related report.</xs:documentation>
+							<xs:documentation>This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is ReportType in the http://stix.mitre.org/Report-1 namespace. This type is defined in the report.xsd file or at the URL http://stix.mitre.org/XMLSchema/report/1.2/report.xsd.</xs:documentation>
+						</xs:annotation>
+					</xs:element>
+				</xs:sequence>
+			</xs:extension>
+		</xs:complexContent>
+	</xs:complexType>
 	<xs:complexType name="RelatedIdentityType">
 		<xs:annotation>
 			<xs:documentation>Identifies or characterizes a relationship to an Identity.</xs:documentation>
@@ -654,6 +671,29 @@
 			</xs:annotation>
 		</xs:attribute>
 	</xs:complexType>
+	<xs:complexType name="ReportBaseType">
+		<xs:annotation>
+			<xs:documentation>This type represents the STIX Report component. It is extended using the XML Schema Extension feature by the STIX Report type itself. Users of this type who wish to express a full report using STIX must do so using the xsi:type extension feature. The STIX-defined Report type is ReportType in the http://stix.mitre.org/Report-1 namespace. This type is defined in the report.xsd file or at the URL http://stix.mitre.org/XMLSchema/report/1.2/report.xsd.</xs:documentation>
+			<xs:documentation>Alternatively, uses that require simply specifying an idref as a reference to a report defined elsewhere can do so without specifying an xsi:type.</xs:documentation>
+		</xs:annotation>
+		<xs:attribute name="id" type="xs:QName">
+			<xs:annotation>
+				<xs:documentation>Specifies a globally unique identifier for this Report. </xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="idref" type="xs:QName">
+			<xs:annotation>
+				<xs:documentation>Specifies a globally unique identifier of a Report specified elsewhere.</xs:documentation>
+				<xs:documentation>When idref is specified, the id attribute must not be specified, and any instance of this Report should not hold content.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+		<xs:attribute name="timestamp" type="xs:dateTime">
+			<xs:annotation>
+				<xs:documentation>Specifies a timestamp for the definition of a specific version of a Report. When used in conjunction with the id, this field is specifying the definition time for the specific version of the Report. When used in conjunction with the idref, this field is specifying a reference to a specific version of a Report defined elsewhere. This field has no defined semantic meaning if used in the absence of either the id or idref fields.</xs:documentation>
+			</xs:annotation>
+		</xs:attribute>
+	</xs:complexType>
+
 	<!-- End of component base types -->
 	<xs:complexType name="ExploitTargetsType">
 		<xs:sequence>

--- a/stix_default_vocabularies.xsd
+++ b/stix_default_vocabularies.xsd
@@ -12,14 +12,145 @@
 	</xs:annotation>
 	<xs:import namespace="http://stix.mitre.org/common-1" schemaLocation="stix_common.xsd"/>
 	<xs:import namespace="http://cybox.mitre.org/common-2" schemaLocation="cybox/cybox_common.xsd"/>
+	<!-- Report Intent Vocabulary -->
+	<xs:complexType name="ReportIntentVocab-1.0">
+		<xs:annotation>
+			<xs:documentation>
+				The ReportIntentVocab is the default STIX vocabulary for the ReportType Intent field.
+				
+				Note that this vocabulary is under development. Feedback is appreciated and should be sent to the STIX discussion list.
+			</xs:documentation>
+		</xs:annotation>
+		<xs:simpleContent>
+			<xs:restriction base="stixCommon:ControlledVocabularyStringType">
+				<xs:simpleType>
+					<xs:union memberTypes="stixVocabs:ReportIntentEnum-1.0"/>
+				</xs:simpleType>
+				<xs:attribute name="vocab_name" type="xs:string" use="optional" fixed="STIX Default Report Intent Vocabulary"/>
+				<xs:attribute name="vocab_reference" type="xs:anyURI" use="optional" fixed="http://stix.mitre.org/XMLSchema/default_vocabularies/1.2.0/stix_default_vocabularies.xsd#ReportIntentVocab-1.0"/>
+			</xs:restriction>
+		</xs:simpleContent>
+	</xs:complexType>
+	<xs:simpleType name="ReportIntentEnum-1.0">
+		<xs:annotation>
+			<xs:documentation>The default set of values to use for a report intent in STIX.</xs:documentation>
+			<xs:appinfo>
+				<version>1.0</version>
+			</xs:appinfo>
+		</xs:annotation>
+		<xs:restriction base="xs:string">
+			<xs:enumeration value="Collective Threat Intelligence">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe a broad characterization of a threat across multiple facets.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Threat Report">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe a broad characterization of a threat across multiple facets expressed as a cohesive report.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Indicators">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly indicators.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Indicators - Phishing">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly phishing indicators.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Indicators - Watchlist">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly network watchlist indicators.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Indicators - Malware Artifacts">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly malware artifact indicators.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Indicators - Network Activity">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly network activity indicators.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Indicators - Endpoint Characteristics">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly endpoint characteristics (hashes, registry values, installed software, known vulnerabilities, etc.) indicators.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Campaign Characterization">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of one or more campaigns.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Threat Actor Characterization">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of one or more threat actors.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Exploit Characterization">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of one or more exploits.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Attack Pattern Characterization">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of one or more attack patterns.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Malware Characterization">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of one or more malware instances.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TTP - Infrastructure">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of attacker infrastructure.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="TTP - Tools">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a characterization of attacker tools.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Courses of Action">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly a set of courses of action.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Incident">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly information about one or more incidents.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Observations">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly information about instantial observations (cyber observables).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Observations - Email">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe mainly information about instantial email observations (email cyber observables).</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+			<xs:enumeration value="Malware Samples">
+				<xs:annotation>
+					<xs:documentation>Report is intended to describe a set of malware samples.</xs:documentation>
+				</xs:annotation>
+			</xs:enumeration>
+		</xs:restriction>
+	</xs:simpleType>
 	<!-- Package Intent Vocabulary -->
 	<xs:complexType name="PackageIntentVocab-1.0">
 		<xs:annotation>
 			<xs:documentation>
                 The PackageIntentVocab is the default STIX vocabulary for Package Intent.
-            
-                Note that this vocabulary is under development. Feedback is appreciated and should be sent to the STIX discussion list.
             </xs:documentation>
+			<xs:documentation>NOTE: As of STIX Version 1.2, the PackageIntentVocab is deprecated and should only be used with the deprecated STIXHeaderType/Package_Intent field. Please use a Report and ReportIntentVocab-1.0 instead.</xs:documentation>
+			<xs:appinfo>
+				<deprecated>true</deprecated>
+			</xs:appinfo>
 		</xs:annotation>
 		<xs:simpleContent>
 			<xs:restriction base="stixCommon:ControlledVocabularyStringType">
@@ -34,8 +165,10 @@
 	<xs:simpleType name="PackageIntentEnum-1.0">
 		<xs:annotation>
 			<xs:documentation>The default set of values to use for a package intent in STIX.</xs:documentation>
+			<xs:documentation>NOTE: As of STIX Version 1.2, the PackageIntentEnum is deprecated and should only be used with the deprecated STIXHeaderType/Package_Intent field. Please use a Report and ReportIntentEnum-1.0 instead.</xs:documentation>
 			<xs:appinfo>
 				<version>1.0</version>
+				<deprecated>true</deprecated>
 			</xs:appinfo>
 		</xs:annotation>
 		<xs:restriction base="xs:string">


### PR DESCRIPTION
This commit:

* Creates a new report.xsd schema
* Copies the existing STIXType schema to that
* Renames everything to Report
* Adds ReportBaseType and RelatedReportType to STIX Common

It does not:
* Alter STIX_Package to add report
* Deprecate anything on STIX_Package
* Deprecate Associated_Packages

See #223
