### PR TITLE
Deprecates Related_Package on constructs per #223

### DIFF
--- a/campaign.xsd
+++ b/campaign.xsd
@@ -116,6 +116,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>

--- a/course_of_action.xsd
+++ b/course_of_action.xsd
@@ -113,6 +113,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>

--- a/exploit_target.xsd
+++ b/exploit_target.xsd
@@ -83,6 +83,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>

--- a/incident.xsd
+++ b/incident.xsd
@@ -184,6 +184,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>

--- a/indicator.xsd
+++ b/indicator.xsd
@@ -130,6 +130,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 					<xs:element name="Producer" type="stixCommon:InformationSourceType" minOccurs="0">

--- a/threat_actor.xsd
+++ b/threat_actor.xsd
@@ -121,6 +121,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>

--- a/ttp.xsd
+++ b/ttp.xsd
@@ -104,6 +104,10 @@
 					<xs:element name="Related_Packages" type="stixCommon:RelatedPackageRefsType" minOccurs="0">
 						<xs:annotation>
 							<xs:documentation>The Related_Packages field identifies or characterizes relationships to set of related Packages.</xs:documentation>
+							<xs:documentation>DEPRECATED: This field is deprecated and will be removed in the next major version of STIX. Its use is strongly discouraged except for legacy applications.</xs:documentation>
+							<xs:appinfo>
+								<deprecated>true</deprecated>
+							</xs:appinfo>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>


### PR DESCRIPTION
Created as a PR against the package changes branch rather than the parent because that one hasn't been merged yet.