### PR TITLE
Removed unnecessary xmlns declaration from CVRF schema

### DIFF
--- a/extensions/vulnerability/cvrf_1.1_vulnerability.xsd
+++ b/extensions/vulnerability/cvrf_1.1_vulnerability.xsd
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" xmlns:stix-cvrf="http://stix.mitre.org/extensions/Vulnerability#CVRF-1" targetNamespace="http://stix.mitre.org/extensions/Vulnerability#CVRF-1" xmlns="http://stix.mitre.org/extensions/Vulnerability#CVRF-1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:et="http://stix.mitre.org/ExploitTarget-1" version="1.1.1" xml:lang="English">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified" xmlns:stix-cvrf="http://stix.mitre.org/extensions/Vulnerability#CVRF-1" targetNamespace="http://stix.mitre.org/extensions/Vulnerability#CVRF-1" xmlns:cvrf="http://www.icasi.org/CVRF/schema/cvrf/1.1" xmlns:et="http://stix.mitre.org/ExploitTarget-1" version="1.1.1" xml:lang="English">
     <xs:annotation>
         <xs:documentation>This schema was originally developed by The MITRE Corporation. The STIX XML Schema implementation is maintained by The MITRE Corporation and developed by the open STIX Community. For more information, including how to get involved in the effort and how to submit change requests, please visit the STIX website at http://stix.mitre.org. </xs:documentation>
         <xs:appinfo>

--- a/test_manifest.cfg
+++ b/test_manifest.cfg
@@ -10,6 +10,7 @@ issues/issue_218/newvocab-oldvalues.xml,neg
 issues/issue_218/newvocab.xml,pos
 issues/issue_218/oldvocab-newvalues.xml,neg
 issues/issue_218/oldvocab.xml,pos
+issues/issue_135/cvrf_extension.xml,pos
 veris/0001AA7F-C601-424A-B2B8-BE6C9F5164E7.xml,pos
 veris/0012CC25-9167-40D8-8FE3-3D0DFD8FB6BB.xml,pos
 veris/00163384-B4D7-46D5-9E6F-543DFB00F598.xml,pos


### PR DESCRIPTION
Fixes #135 

This was causing some of the documentation generation to act funky because the annotations would be in the cvrf namespace rather than no namespace.