### PR TITLE
Updated Discovery_Method annotation to refer to 2.0 vocabulary.

### DIFF
--- a/incident.xsd
+++ b/incident.xsd
@@ -133,7 +133,7 @@
 					<xs:element name="Discovery_Method" type="stixCommon:ControlledVocabularyStringType" minOccurs="0" maxOccurs="unbounded">
 						<xs:annotation>
 							<xs:documentation>The Discovery_Method field identifies how the incident was discovered.</xs:documentation>
-							<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. The default vocabulary type is DiscoveryMethodVocab-1.0 in the http://stix.mitre.org/default_vocabularies-1 namespace. This type is defined in the stix_default_vocabularies.xsd file or at the URL http://stix.mitre.org/XMLSchema/default_vocabularies/1.2.0/stix_default_vocabularies.xsd.</xs:documentation>
+							<xs:documentation>This field is implemented through the xsi:type controlled vocabulary extension mechanism. The default vocabulary type is DiscoveryMethodVocab-2.0 in the http://stix.mitre.org/default_vocabularies-1 namespace. This type is defined in the stix_default_vocabularies.xsd file or at the URL http://stix.mitre.org/XMLSchema/default_vocabularies/1.2.0/stix_default_vocabularies.xsd.</xs:documentation>
 							<xs:documentation>Users may also define their own vocabulary using the type extension mechanism, specify a vocabulary name and reference using the attributes, or simply use this as a string field.</xs:documentation>
 						</xs:annotation>
 					</xs:element>


### PR DESCRIPTION
I'm not sure if this is correct, but the annotations for `incident:Discovery_Method` still point at the `1.0` vocabulary so I updated it to refer to the `2.0` vocab.