### PR TITLE
remove incorrect xs:documentation text from RelatedPackageType

### DIFF
--- a/stix_core.xsd
+++ b/stix_core.xsd
@@ -277,7 +277,6 @@
 					<xs:element name="Package" type="stix:STIXType">
 						<xs:annotation>
 							<xs:documentation>A reference to or representation of the related Package.</xs:documentation>
-							<xs:documentation>This field is implemented through the xsi:type extension mechanism. The default and strongly recommended type is IncidentType in the http://stix.mitre.org/Incident-1 namespace. This type is defined in the incident.xsd file or at the URL http://stix.mitre.org/XMLSchema/incident/1.2/incident.xsd.</xs:documentation>
 						</xs:annotation>
 					</xs:element>
 				</xs:sequence>


### PR DESCRIPTION
The old RelatedPackageType text referred to the IncidentType; it looks like this text was incorrectly copied from the IncidentsType definition earlier in this file.

I just removed it, which leaves the remaining text consistent with the RelatedPackagesType.  If more descriptive text is desired, of course feel free.